### PR TITLE
fix : faetures quickNavi sticky

### DIFF
--- a/src/main/resources/static/css/article/features.css
+++ b/src/main/resources/static/css/article/features.css
@@ -33,6 +33,7 @@
 .features-intro-content {
     width: 280px;
     flex-shrink: 0;
+    height: 100rem;
 }
 .features-intro-content > h2 {
     width: 210px;


### PR DESCRIPTION
- 퀵네비 sticky적용안되는거 고침
- 해당 frag의 부모 요소의 height를 html보다 크거나 잡게 설정해줘야 함
- 100rem(1600px)으로 할당