### PR TITLE
hotfix : faetures quickNavi sticky

### DIFF
--- a/src/main/resources/static/css/article/features.css
+++ b/src/main/resources/static/css/article/features.css
@@ -33,7 +33,7 @@
 .features-intro-content {
     width: 280px;
     flex-shrink: 0;
-    height: 100rem;
+    height: 120rem;
 }
 .features-intro-content > h2 {
     width: 210px;


### PR DESCRIPTION
- 부모요소(features-intro-content) height : 100rem이 아니라 120rem으로 수정
- resolved #23 